### PR TITLE
updated version for node in package.json to correct build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "request": "~2.33.0"
   },
   "engines": {
-    "node": "0.10.7"
+    "node": "^0.10.36"
   },
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Was getting a build error when attempting to push to Heroku (error below). Fixed it by updating the package.json version for node.

npm ERR! Error: No compatible version found: coveralls@'^2.11.2'
remote:        npm ERR! Valid install targets:
remote:        npm ERR! ["1.0.0","1.1.0","1.1.1","1.1.2","1.1.3","2.0.0","2.0.1","2.0.2","2.0.3","2.0.4","2.0.5","2.0.6","2.0.7","2.0.8","2.0.9","2.0.10","2.0.11","2.0.12","2.0.13","2.0.15","2.0.16","2.1.0","2.2.0","2.3.0","2.5.0","2.6.0","2.6.1","2.7.0","2.7.1","2.8.0","2.10.0","2.10.1","2.11.0","2.11.1","2.11.2"]
remote:        npm ERR!     at installTargetsError (/tmp/build_537f525857fe96ac596d66019c8575be/.heroku/node/lib/node_modules/npm/lib/cache.js:709:10)
remote:        npm ERR!     at /tmp/build_537f525857fe96ac596d66019c8575be/.heroku/node/lib/node_modules/npm/lib/cache.js:631:10
remote:        npm ERR!     at saved (/tmp/build_537f525857fe96ac596d66019c8575be/.heroku/node/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:138:7)
remote:        npm ERR!     at Object.oncomplete (fs.js:107:15)
remote:        npm ERR! If you need help, you may report this log at:
remote:        npm ERR!     <http://github.com/isaacs/npm/issues>
remote:        npm ERR! or email it to:
remote:        npm ERR!     <npm-@googlegroups.com>
